### PR TITLE
utilise service when connecting to selenium

### DIFF
--- a/scrapy_selenium/middlewares.py
+++ b/scrapy_selenium/middlewares.py
@@ -46,24 +46,24 @@ class SeleniumMiddleware:
         for argument in driver_arguments:
             driver_options.add_argument(argument)
 
-        driver_kwargs = {
-            'executable_path': driver_executable_path,
-            f'{driver_name}_options': driver_options
-        }
-
         # locally installed driver
         if driver_executable_path is not None:
-            driver_kwargs = {
+            service_module = import_module(f'{webdriver_base_path}.service')
+            service_klass = getattr(service_module, 'Service')
+            service_kwargs = {
                 'executable_path': driver_executable_path,
-                f'{driver_name}_options': driver_options
+            }
+            service = service_klass(**service_kwargs)
+            driver_kwargs = {
+                'service': service,
+                'options': driver_options
             }
             self.driver = driver_klass(**driver_kwargs)
         # remote driver
         elif command_executor is not None:
             from selenium import webdriver
-            capabilities = driver_options.to_capabilities()
             self.driver = webdriver.Remote(command_executor=command_executor,
-                                           desired_capabilities=capabilities)
+                                           options=driver_options)
 
     @classmethod
     def from_crawler(cls, crawler):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = scrapy-selenium
-version = 0.0.7
+version = 0.0.8
 url = https://github.com/clemfromspace/scrapy-selenium
 licence = DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
 description = Scrapy with selenium


### PR DESCRIPTION
1. Fixed the executable_path TypeError https://github.com/clemfromspace/scrapy-selenium/commit/5c3fe7b43ab336349ef5fdafe39fc87f6a8a8c34
2. Fixing remote driver functionality by fixing the deprecated desired_capabilities for options.